### PR TITLE
Fix display bug, add event listeners to calls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
             <input id="phone-number" type="text" placeholder="+15552221234" />
             <button id="button-call" type="submit">Call</button>
           </form>
-          <button id="button-hangup" class="hide">Hang Up</button>
+          <button id="button-hangup-outgoing" class="hide">Hang Up</button>
           <div id="incoming-call" class="hide">
             <h2>Incoming Call Controls</h2>
             <p class="instructions">

--- a/src/handler.js
+++ b/src/handler.js
@@ -31,14 +31,13 @@ exports.tokenGenerator = function tokenGenerator() {
 
 exports.voiceResponse = function voiceResponse(requestBody) {
   const toNumberOrClientName = requestBody.To;
-
+  const callerId = config.callerId;
   let twiml = new VoiceResponse();
 
   // If the request to the /voice endpoint is TO your Twilio Number, 
   // then it is an incoming call towards your Twilio.Device.
-  if (requestBody.To == config.callerId) {
-    
-    dial = twiml.dial();
+  if (toNumberOrClientName == callerId) {
+    let dial = twiml.dial();
 
     // This will connect the caller with your Twilio.Device/client 
     dial.client(identity);
@@ -47,7 +46,7 @@ exports.voiceResponse = function voiceResponse(requestBody) {
     // This is an outgoing call
 
     // set the callerId
-    dial = twiml.dial({ callerId: config.callerId });
+    let dial = twiml.dial({ callerId });
 
     // Check if the 'To' parameter is a Phone Number or Client Name
     // in order to use the appropriate TwiML noun 


### PR DESCRIPTION
1. **Renamed elements and functions for clarity:**
    - Renamed 'hangupButton' to `outgoingCallHangupButton` in `quickstart.js`, along with corresponding html element id from `button-hangup` to `button-hangup-outgoing`
    - Renamed functions to indicate whether they apply to outgoing or incoming calls
1. **Removed `hangup()` function:** 
    - Using `call.disconnect()` rather than `device.disconnectAll()`. 
1. **Changed `.addEventListener`s to `.on`s to maintain consistency across the application.**
1. **Added event listeners on Call instances to update UI appropriately:**
    - Listen for `disconnect` and `reject` events on incoming Call instance
    - Listen for `cancel` and `reject` events on outgoing Call instance
1. **Fix resetIncomingCallUI Bug:**
    - Some of the controls were not appropriately showing/hiding after an incoming call ended
1. **Refactored `handler.js`:**
    - Added `let` in front of `dial` that was accidentally declared as a global variable
    - Saved `config.callerId` to `const callerId`